### PR TITLE
Allow the installer script to accept a version number and installation prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,42 @@ The syntax is `[tag:label]` for tags and `[ref:label]` for references. Tagref wo
 
 ## Installation
 
-If you are running macOS or a GNU-based Linux on an x86-64 CPU, the following will install Tagref in `/usr/local/bin`:
+### Default installation
+
+If you are running macOS or a GNU-based Linux on an x86-64 CPU, you can install Tagref with this command:
 
 ```sh
 curl -LSfs https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh | sudo sh
 ```
 
-If you want to install to a different location, you can download a binary from the [releases page](https://github.com/stepchowfun/tagref/releases) and put it anywhere on your `$PATH`. If there is no pre-built binary available for your platform, you can build and install it with [Cargo](https://doc.rust-lang.org/book/second-edition/ch14-04-installing-binaries.html).
+The same command can be used to update Tagref to the latest version.
+
+### Custom installation
+
+The installation script supports the following environment variables:
+
+- `VERSION=x.y.z` (defaults to the latest version)
+- `PREFIX=/path/to/install` (defaults to `/usr/local/bin`)
+
+For example, the following will install Tagref into the current directory:
+
+```sh
+curl -LSfs https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh | PREFIX=. sh
+```
+
+### Installation on other platforms
+
+If there is no pre-built binary available for your platform, you can build and install Tagref with [Cargo](https://doc.rust-lang.org/book/second-edition/ch14-04-installing-binaries.html):
+
+```sh
+cargo install tagref
+```
+
+Then you can update Tagref to the latest version using the `--force` flag:
+
+```sh
+cargo install tagref --force
+```
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 
+# Usage examples:
+#   ./install.sh
+#   VERSION=x.y.z ./install.sh
+#   PREFIX=/usr/local/bin ./install.sh
+
 # Where the binary will be installed
-PREFIX=/usr/local/bin
+DESTINATION="${PREFIX:-/usr/local/bin}/tagref"
 
 # Which version to download
-RELEASE=v0.0.4
+RELEASE="v${VERSION:-0.0.4}"
 
 # Determine which binary to download.
 FILENAME=''
@@ -24,13 +29,13 @@ if [ -z "$FILENAME" ]; then
 fi
 
 # Download the binary.
-if ! curl -LSf "https://github.com/stepchowfun/tagref/releases/download/$RELEASE/$FILENAME" -o "$PREFIX/tagref"; then
+if ! curl -LSf "https://github.com/stepchowfun/tagref/releases/download/$RELEASE/$FILENAME" -o "$DESTINATION"; then
   echo 'There was an error downloading the binary.' 1>&2
   exit 1
 fi
 
 # Make it executable.
-if ! chmod a+rx "$PREFIX/tagref"; then
+if ! chmod a+rx "$DESTINATION"; then
   echo 'There was an error setting the permissions for the binary.' 1>&2
   exit 1
 fi


### PR DESCRIPTION
Allow the installer script to accept a version number and installation prefix. Examples:

```sh
$ curl -LSfs https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh | sudo sh
$ curl -LSfs https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh | sudo VERSION=0.0.4 sh
$ curl -LSfs https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh | sudo PREFIX=/usr/local/bin sh
```

cc @larat7

**Status:** Ready

**Fixes:** N/A
