### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/citations.rs
+++ b/src/citations.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 // tag is encountered, an error message is returned.
 pub fn check(
   tags: &HashMap<String, super::label::Label>,
-  references: &Vec<super::label::Label>
+  references: &[super::label::Label]
 ) -> Option<String> {
   let mut error = String::new();
   let mut missing_tags = false;

--- a/src/label.rs
+++ b/src/label.rs
@@ -52,10 +52,10 @@ pub fn parse(label_type: LabelType, path: &str, contents: &str) -> Vec<Label> {
       // If we got a match, then captures.get(1) is guaranteed to return a
       // Some. Hence we are justified in unwrapping.
       labels.push(Label {
-        label_type: label_type,
+        label_type,
         label: captures.get(1).unwrap().as_str().trim().to_string(),
         path: path.to_string(),
-        line_number: line_number,
+        line_number,
       });
     }
     line_number += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
     Ok(tags) => {
       // Handle the --list-tags flag if necessary.
       if list_tags {
-        for (_, tag) in &tags {
+        for tag in tags.values() {
           println!("{}", tag);
         }
       }
@@ -106,8 +106,8 @@ fn main() {
               "{}",
               format!(
                 "{} and {} validated in {}.",
-                count::count(tags.len().into(), "tag"),
-                count::count(references.len().into(), "reference"),
+                count::count(tags.len(), "tag"),
+                count::count(references.len(), "reference"),
                 count::count(files_scanned, "file")
               ).green()
             );

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -16,7 +16,7 @@ pub fn walk<T: FnMut(&str, &str) -> ()>(path: &str, mut callback: T) -> usize {
         let mut possible_file = File::open(dir_entry.path());
         if let Ok(mut file) = possible_file {
           let mut contents = String::new();
-          if let Ok(_) = file.read_to_string(&mut contents) {
+          if file.read_to_string(&mut contents).is_ok() {
             files_scanned += 1;
             callback(
               &dir_entry.path().to_string_lossy().into_owned(),


### PR DESCRIPTION
Previously I was unable to install [Clippy](https://github.com/rust-lang-nursery/rust-clippy), becuase it wouldn't compile against stable or nightly Rust. But I tried again today and it worked. This PR fixes all the warnings that Clippy produced.

Thanks @larat7 for suggesting that I use Clippy. :)

**Status:** Ready

**Fixes:** N/A
