### PR TITLE
Make Tagref faster by pre-compiling regular expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 atty = "0.2"
 colored = "1"
 ignore = "0.4"
+lazy_static = "1.3"
 regex = "1"
 
 [dependencies.clap]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use std::{
   sync::{Arc, Mutex},
 };
 
+#[macro_use]
+extern crate lazy_static;
+
 // The program version
 const VERSION: &str = "0.0.8";
 


### PR DESCRIPTION
Make Tagref faster by pre-compiling regular expressions.