### PR TITLE
Release v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tagref"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Tagref helps you refer to other locations in your codebase."
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::{
 extern crate lazy_static;
 
 // The program version
-const VERSION: &str = "0.1.0";
+const VERSION: &str = "1.0.0";
 
 // Command-line option and subcommand names
 const CHECK_COMMAND: &str = "check";


### PR DESCRIPTION
Release v1.0.0. Tagref is mature:

- There are no known bugs.
- Tagref is feature complete.
- Tagref is fast. All obvious optimizations (e.g., parallelization, precompiling regexes, etc.) have been implemented.
- The code was written thoughtfully, its formatting agrees with `rustfmt`, it passes `clippy`, it passes Tagref itself, and there is a test suite.
- Error messages are clear and use proper punctuation, capitalization, etc.
- There is documentation.

It's time for the version number to reflect that maturity.

@juliahw