### PR TITLE
Support multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ USAGE:
     tagref [SUBCOMMAND]
 
 OPTIONS:
-    -h, --help           Prints help information
-    -p, --path <PATH>    Sets the path of the directory to scan
-    -v, --version        Prints version information
+    -h, --help              Prints help information
+    -p, --path <PATH>...    Sets the path of the directory to scan
+    -v, --version           Prints version information
 
 SUBCOMMANDS:
     check          Check all the tags and references (default)

--- a/src/label.rs
+++ b/src/label.rs
@@ -168,7 +168,6 @@ mod tests {
     assert_ne!(tags[0].label, tags[1].label);
   }
 
-
   #[test]
   fn parse_multiple_per_line() {
     let path = Path::new("file.rs").to_owned();

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,7 +1,7 @@
 use ignore::{WalkBuilder, WalkState};
 use std::{
   fs::File,
-  path::Path,
+  path::{Path, PathBuf},
   sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -13,42 +13,45 @@ use std::{
 // (e.g., due to lack of permissions). It also skips over symlinks. The number
 // of files traversed is returned.
 pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File) -> ()>(
-  path: &Path,
+  paths: &[PathBuf],
   callback: T,
 ) -> usize {
   // Keep track of the number of files traversed, and allow multiple threads to
   // update it.
   let files_scanned = Arc::new(AtomicUsize::new(0));
 
-  // Traverse the filesystem in parallel.
-  WalkBuilder::new(path).build_parallel().run(|| {
-    // These clones will be moved into the closure below, and that closure will
-    // be sent to a new thread.
-    let mut callback = callback.clone();
-    let files_scanned = files_scanned.clone();
+  // Scan each of the given paths.
+  for path in paths {
+    // Traverse the filesystem in parallel.
+    WalkBuilder::new(path).build_parallel().run(|| {
+      // These clones will be moved into the closure below, and that closure will
+      // be sent to a new thread.
+      let mut callback = callback.clone();
+      let files_scanned = files_scanned.clone();
 
-    // This closure will be sent to a new thread.
-    Box::new(move |result| {
-      // Proceed if we have access to the path.
-      if let Ok(dir_entry) = result {
-        // Here, `file_type()` should always return a `Some`. It could only
-        // return `None` if the file represents STDIN, and that isn't the case
-        // here.
-        if dir_entry.file_type().unwrap().is_file() {
-          // Try to open the file.
-          let possible_file = File::open(dir_entry.path());
-          if let Ok(file) = possible_file {
-            // Process the file and increment the counter.
-            callback(dir_entry.path(), file);
-            files_scanned.fetch_add(1, Ordering::SeqCst);
+      // This closure will be sent to a new thread.
+      Box::new(move |result| {
+        // Proceed if we have access to the path.
+        if let Ok(dir_entry) = result {
+          // Here, `file_type()` should always return a `Some`. It could only
+          // return `None` if the file represents STDIN, and that isn't the case
+          // here.
+          if dir_entry.file_type().unwrap().is_file() {
+            // Try to open the file.
+            let possible_file = File::open(dir_entry.path());
+            if let Ok(file) = possible_file {
+              // Process the file and increment the counter.
+              callback(dir_entry.path(), file);
+              files_scanned.fetch_add(1, Ordering::SeqCst);
+            }
           }
         }
-      }
 
-      // Don't stop...believing!
-      WalkState::Continue
-    })
-  });
+        // Don't stop...believing!
+        WalkState::Continue
+      })
+    });
+  }
 
   // Return the number of files traversed.
   files_scanned.load(Ordering::SeqCst)


### PR DESCRIPTION
@juliahw had the great idea to support scanning multiple paths. After this change, you can do:

```sh
tagref --path path1 --path path2 ...
```

This is not the same as running Tagref on each of the paths separately:

```sh
tagref --path path1
tagref --path path2
...
```

In the first example, files from `path1` can reference tags in files from `path2`, and vice versa. In the second example, each of the paths must be self-contained with respect to tags and references.