### PR TITLE
Don't check the checksum in the installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,17 +52,6 @@
     fail 'There was an error downloading the binary.'
   fi
 
-  # Download the checksum.
-  if ! curl "https://github.com/stepchowfun/tagref/releases/download/$RELEASE/$FILENAME.sha256" \
-      -o "$FILENAME.sha256" -LSf; then
-    fail 'There was an error downloading the checksum.'
-  fi
-
-  # Verify the checksum.
-  if ! shasum --algorithm 256 --check --status "$FILENAME.sha256"; then
-    fail 'The downloaded binary was corrupted. Feel free to try again.'
-  fi
-
   # Make it executable.
   if ! chmod a+rx "$FILENAME"; then
     fail 'There was an error setting the permissions for the binary.'


### PR DESCRIPTION
It seems there isn't a portable way to verify checksums. Many distributions don't ship with `shasum`.

This checksum verification step was somewhat superfluous in the sense that if the data become corrupted over the wire, it would fail to decrypt before we even got to the checksum verification step (the file is downloaded via HTTPS). Also, it was never a security measure because the binary and the checksum are downloaded from the same host, so if one is compromised the other might as well be do. So I feel comfortable removing this unnecessary check to make the installation script more portable.

@juliahw