### PR TITLE
Add support for custom prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2020-07-29
+
+### Added
+- Added support for `--ref-prefix` and `--tag-prefix`.
+
 ## [1.2.1] - 2019-11-26
 
 ### Removed
@@ -18,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2019-05-06
 
 ### Added
-- Support for scanning multiple paths.
+- Added support for scanning multiple paths.
 
 ## [1.0.0] - 2019-05-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,13 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tagref"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Tagref helps you refer to other locations in your codebase."
 license = "MIT"
@@ -14,7 +14,6 @@ edition = "2018"
 atty = "0.2"
 colored = "1"
 ignore = "0.4"
-lazy_static = "1.3"
 regex = "1"
 
 [dependencies.clap]

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ USAGE:
     tagref [SUBCOMMAND]
 
 OPTIONS:
-    -h, --help              Prints help information
-    -p, --path <PATH>...    Sets the path of the directory to scan
-    -v, --version           Prints version information
+    -h, --help                       Prints help information
+    -p, --path <PATH>...             Adds the path of a directory to scan [default: .]
+    -r, --ref-prefix <REF_PREFIX>    Sets the prefix used for locating references [default: ref]
+    -t, --tag-prefix <TAG_PREFIX>    Sets the prefix used for locating tags [default: tag]
+    -v, --version                    Prints version information
 
 SUBCOMMANDS:
     check          Check all the tags and references (default)

--- a/src/references.rs
+++ b/src/references.rs
@@ -25,7 +25,7 @@ pub fn check(tags: &HashMap<String, Label>, refs: &[Label]) -> Result<(), String
 mod tests {
     use crate::{
         label::{Label, Type},
-        r#ref::check,
+        references::check,
     };
     use std::{collections::HashMap, path::Path};
 


### PR DESCRIPTION
Add support for custom prefixes. Now you can write tags like `[mytagprefix:foo]` and reference them with `[myrefprefix:foo]` if you invoke Tagref like `tagref --tag-prefix mytagprefix --ref-prefix myrefprefix`.

cc @juliahw @sharmilajesupaul

**Status:** Ready

**Fixes:** N/A
