### PR TITLE
Precompile regexes to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2020-07-29
+## [1.3.1] - 2020-07-30
+
+### Changed
+- Tagref is now faster because it now compiles the regular expressions once, rather than once per file.
+
+## [1.3.0] - 2020-07-30
 
 ### Added
 - Added support for `--ref-prefix` and `--tag-prefix`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tagref"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Tagref helps you refer to other locations in your codebase."
 license = "MIT"

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,4 +1,4 @@
-use regex::{escape, Regex};
+use regex::Regex;
 use std::{
     fmt,
     io::BufRead,
@@ -38,27 +38,19 @@ impl fmt::Display for Label {
 
 // This function returns all the labels in a file for a given type.
 pub fn parse<R: BufRead>(
-    tag_prefix: &str,
-    ref_prefix: &str,
+    tag_regex: &Regex,
+    ref_regex: &Regex,
     label_type: Type,
     path: &Path,
     reader: R,
 ) -> Vec<Label> {
-    // The `unwrap`s below are safe because we manually inspected the regexes.
     let regex = match label_type {
-        Type::Tag => Regex::new(&format!(
-            "(?i)\\[\\s*{}\\s*:\\s*([^\\]\\s]*)\\s*\\]",
-            escape(tag_prefix)
-        ))
-        .unwrap(),
-        Type::Ref => Regex::new(&format!(
-            "(?i)\\[\\s*{}\\s*:\\s*([^\\]\\s]*)\\s*\\]",
-            escape(ref_prefix)
-        ))
-        .unwrap(),
+        Type::Tag => tag_regex,
+        Type::Ref => ref_regex,
     };
 
     let mut labels: Vec<Label> = Vec::new();
+
     for (line_number, line_result) in reader.lines().enumerate() {
         if let Ok(line) = line_result {
             for captures in regex.captures_iter(&line) {
@@ -80,14 +72,21 @@ pub fn parse<R: BufRead>(
 #[cfg(test)]
 mod tests {
     use crate::label::{parse, Type};
+    use regex::Regex;
     use std::path::Path;
+
+    const TAG_REGEX: &str = "(?i)\\[\\s*tag\\s*:\\s*([^\\]\\s]*)\\s*\\]";
+    const REF_REGEX: &str = "(?i)\\[\\s*ref\\s*:\\s*([^\\]\\s]*)\\s*\\]";
 
     #[test]
     fn parse_empty() {
         let path = Path::new("file.rs").to_owned();
         let contents = b"" as &[u8];
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert!(tags.is_empty());
     }
@@ -101,7 +100,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].label_type, Type::Tag);
@@ -119,7 +121,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let refs = parse("tag", "ref", Type::Ref, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let refs = parse(&tag_regex, &ref_regex, Type::Ref, &path, contents);
 
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].label_type, Type::Ref);
@@ -137,7 +142,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].label_type, Type::Tag);
@@ -156,7 +164,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert_eq!(tags.len(), 2);
         assert_eq!(tags[0].label_type, Type::Tag);
@@ -179,7 +190,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert_eq!(tags.len(), 2);
         assert_eq!(tags[0].label_type, Type::Tag);
@@ -202,7 +216,10 @@ mod tests {
         .trim()
         .as_bytes();
 
-        let tags = parse("tag", "ref", Type::Tag, &path, contents);
+        let tag_regex: Regex = Regex::new(TAG_REGEX).unwrap();
+        let ref_regex: Regex = Regex::new(REF_REGEX).unwrap();
+
+        let tags = parse(&tag_regex, &ref_regex, Type::Tag, &path, contents);
 
         assert_eq!(tags.len(), 2);
         assert_eq!(tags[0].label_type, Type::Tag);


### PR DESCRIPTION
Precompile regexes to improve performance.

Before:

```sh
tagref  8.17s user 3.61s system 96% cpu 12.192 total
```

After:

```sh
tagref  3.43s user 3.49s system 68% cpu 10.104 total
```

These are sample runs, but they are adequately representative of the average of a few runs.

**Status:** Ready

**Fixes:** N/A
