### PR TITLE
Convert build warnings into errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 mod count;
 mod duplicates;
 mod label;


### PR DESCRIPTION
Convert build warnings into errors.

**Status:** Ready

**Fixes:** N/A
