### PR TITLE
Upgrade to Rust 2021 Edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
         set -euo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.55.0 # [ref:rust_1_55_0]
-        rustup default 1.55.0 # [ref:rust_1_55_0]
+        rustup toolchain install 1.56.0 # [ref:rust_1_56_0]
+        rustup default 1.56.0 # [ref:rust_1_56_0]
 
         # Build and test.
         RUSTFLAGS='--codegen target-feature=+crt-static' cargo build \
@@ -75,8 +75,8 @@ jobs:
         set -euo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.55.0 # [ref:rust_1_55_0]
-        rustup default 1.55.0 # [ref:rust_1_55_0]
+        rustup toolchain install 1.56.0 # [ref:rust_1_56_0]
+        rustup default 1.56.0 # [ref:rust_1_56_0]
 
         # Build and test.
         cargo build --locked --release --target x86_64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tagref"
 version = "1.5.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
-edition = "2018"
+edition = "2021"
 description = "Tagref helps you refer to other locations in your codebase."
 license = "MIT"
 documentation = "https://github.com/stepchowfun/tagref"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ But that solution isn't ideal, because then the reader has to manually sift thro
 *Tagref* solves this problem in a better way. It allows you to annotate your code with "tags" (in comments), which can be referenced from other parts of the codebase. For example, you might have a tag like this:
 
 ```python
-# This function always returns a non-empty list. [tag:flobs_nonempty]
+# [tag:flobs_nonempty] This function always returns a non-empty list.
 def get_flobs():
   return ['hello', 'world']
 ```

--- a/toast.yml
+++ b/toast.yml
@@ -17,8 +17,8 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2021_09_08].
-  cargo-fmt () { cargo +nightly-2021-09-08 --frozen --offline fmt --all -- "$@"; }
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly].
+  cargo-fmt () { cargo +nightly-2021-10-22 --frozen --offline fmt --all -- "$@"; }
 tasks:
   install_packages:
     description: Install system packages.
@@ -55,18 +55,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust. [tag:rust_1_55_0]
+      # Install stable Rust [tag:rust_1_56_0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.55.0 \
+        --default-toolchain 1.56.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2021_09_08].
-      rustup toolchain install nightly-2021-09-08 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly].
+      rustup toolchain install nightly-2021-10-22 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.
@@ -117,7 +117,7 @@ tasks:
       - build
     command: |
       # Run the tests with Cargo. The `NO_COLOR` variable is used to disable colored output for
-      # tests that make assertions regarding the output. [tag:colorless_tests]
+      # tests that make assertions regarding the output [tag:colorless_tests].
       NO_COLOR=true cargo-offline test
 
   lint:
@@ -182,7 +182,7 @@ tasks:
       - src
     command: |
       # Format the code with Rustfmt. We temporarily convert macro invocations into function calls
-      # so Rustfmt's `trailing_comma` feature applies to macro arguments. [tag:format_macros]
+      # so Rustfmt's `trailing_comma` feature applies to macro arguments [tag:format_macros].
       rg '!\(' --type rust --files-with-matches src | xargs sed -i 's/!(/_(/g'
       cargo-fmt
       rg '_\(' --type rust --files-with-matches src | xargs sed -i 's/_(/!(/g'


### PR DESCRIPTION
Upgrade to Rust 2021 Edition.

**Status:** Ready / In development

**Fixes:** N/A