### PR TITLE
Output list-refs results as columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,16 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "colonnade"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4dbabb2946c90155114005a55086e08537be51d4c12af4ac215744e6e719851"
+dependencies = [
+ "strip-ansi-escapes",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -176,6 +192,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50686e0021c4136d1d453b2dfe059902278681512a34d4248435dc34b6b5c8ec"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,9 +256,11 @@ version = "1.5.0"
 dependencies = [
  "atty",
  "clap",
+ "colonnade",
  "colored",
  "ignore",
  "regex",
+ "term_size",
 ]
 
 [[package]]
@@ -248,16 +293,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ readme = "README.md"
 
 [dependencies]
 atty = "0.2"
+colonnade = "1.3.2"
 colored = "1"
 ignore = "0.4"
 regex = "1"
+term_size = "0.3"
 
 [dependencies.clap]
 version = "2"

--- a/src/label.rs
+++ b/src/label.rs
@@ -13,6 +13,19 @@ pub enum Type {
     Ref,
 }
 
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Type::Tag => "tag",
+                Type::Ref => "ref",
+            },
+        )
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Label {
     pub label_type: Type,
@@ -27,10 +40,7 @@ impl fmt::Display for Label {
         write!(
             f,
             "[{}:{}] @ {}:{}",
-            match self.label_type {
-                Type::Tag => "tag",
-                Type::Ref => "ref",
-            },
+            self.label_type,
             self.label,
             self.path.to_string_lossy(),
             self.line_number,


### PR DESCRIPTION
A minor change when printing refs/tags and their locations: show them in a table with uniform column widths.

~~Not ready for merge, because I wanted feedback first.~~

- ~~Should this be default or introduce a CLI flag? or environment variable for convenience?~~ It's now default.
- ~~The ref format is changed from [ref:identifier] to identifier but that can be reverted to as it was before~~ Keeping the identifier.

## Example:

```shell
% target/debug/tagref list-refs
?label?                     ./src/main.rs:48              
cities_nonempty             ./README.md:43                
colorless_tests             ./.github/workflows/ci.yml:62 
colorless_tests             ./.github/workflows/ci.yml:83 
excluded_input_paths        ./.gitignore:1                
format_macros               ./toast.yml:148               
gitignore                   ./toast.yml:135               
label1                      ./src/label.rs:133            
path_default                ./src/main.rs:94              
ref_prefix_default          ./src/main.rs:101             
rust_1.65.0                 ./.github/workflows/ci.yml:134
rust_1.65.0                 ./.github/workflows/ci.yml:135
rust_1.65.0                 ./.github/workflows/ci.yml:54 
rust_1.65.0                 ./.github/workflows/ci.yml:55 
rust_1.65.0                 ./.github/workflows/ci.yml:78 
rust_1.65.0                 ./.github/workflows/ci.yml:79 
rust_fmt_nightly_2022-11-03 ./toast.yml:71                
tag_prefix_default          ./src/main.rs:104
```

current output:

```shell
% tagref list-refs             
[ref:rust_fmt_nightly_2022-11-03] @ ./toast.yml:71
[ref:gitignore] @ ./toast.yml:135
[ref:format_macros] @ ./toast.yml:148
[ref:?label?] @ ./src/main.rs:48
[ref:path_default] @ ./src/main.rs:94
[ref:ref_prefix_default] @ ./src/main.rs:101
[ref:tag_prefix_default] @ ./src/main.rs:104
[ref:label1] @ ./src/label.rs:133
[ref:cities_nonempty] @ ./README.md:43
[ref:excluded_input_paths] @ ./.gitignore:1
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:54
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:55
[ref:colorless_tests] @ ./.github/workflows/ci.yml:62
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:78
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:79
[ref:colorless_tests] @ ./.github/workflows/ci.yml:83
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:134
[ref:rust_1.65.0] @ ./.github/workflows/ci.yml:135
```
