### PR TITLE
Fix clippy lints

### DIFF
--- a/src/count.rs
+++ b/src/count.rs
@@ -2,9 +2,9 @@
 // multiplicity (pluralizing if necessary). For example, `count(3, "cow")` becomes "3 cows".
 pub fn count(n: usize, noun: &str) -> String {
     if n == 1 {
-        format!("{} {}", n, noun)
+        format!("{n} {noun}")
     } else {
-        format!("{} {}s", n, noun)
+        format!("{n} {noun}s")
     }
 }
 

--- a/src/duplicates.rs
+++ b/src/duplicates.rs
@@ -13,10 +13,10 @@ pub fn check(tags_map: &HashMap<String, Vec<Label>>) -> Result<HashMap<String, L
     for (label, tags) in tags_map {
         if tags.len() > 1 {
             dupes_found = true;
-            let _ = write!(error, "Duplicate tags found for label `{}`:\n", label);
+            let _ = writeln!(error, "Duplicate tags found for label `{label}`:");
 
             for tag in tags {
-                let _ = write!(error, "  {}\n", tag);
+                let _ = writeln!(error, "  {tag}");
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn entry() -> Result<(), String> {
                     BufReader::new(file),
                 ) {
                     let _lock = mutex.lock().unwrap(); // Safe assuming no poisoning
-                    println!("{}", tag);
+                    println!("{tag}");
                 }
             });
         }
@@ -159,7 +159,7 @@ fn entry() -> Result<(), String> {
                     BufReader::new(file),
                 ) {
                     let _lock = mutex.lock().unwrap(); // Safe assuming no poisoning
-                    println!("{}", r#ref);
+                    println!("{ref}");
                 }
             });
         }
@@ -209,7 +209,7 @@ fn entry() -> Result<(), String> {
             // Print the remaining tags. The `unwrap` is safe assuming no poisoning.
             for tags in tags_map.lock().unwrap().values() {
                 for tag in tags {
-                    println!("{}", tag);
+                    println!("{tag}");
                 }
             }
         }

--- a/src/references.rs
+++ b/src/references.rs
@@ -12,7 +12,7 @@ pub fn check(tags: &HashMap<String, Label>, refs: &[Label]) -> Result<(), String
     for r#ref in refs {
         if !tags.contains_key(&r#ref.label) {
             missing_tags = true;
-            let _ = write!(error, "No tag found for {}.\n", r#ref);
+            let _ = writeln!(error, "No tag found for {ref}.");
         }
     }
 


### PR DESCRIPTION
Fix new default lints for clippy:

- uninlined_format_args
- write_with_newline