### PR TITLE
Fix invalid term_size width

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn print_tabulated(data: Vec<[String; 2]>) {
     // the width is at least 3 to ensure there is enough room for 2 columns with a 1-space margin
     // between them [tag:min_terminal_width].
     let terminal_width = max(
-        term_size::dimensions_stdout().map_or(80, |(_height, width)| width),
+        term_size::dimensions_stdout().map_or(80, |(width, _height)| width),
         3,
     );
 


### PR DESCRIPTION
The order of the values returned by dimensions_stdout() where swapped, they should be (width, height) but were (height, width) instead. (source: <https://docs.rs/term_size/0.3.2/term_size/fn.dimensions_stdout.html>)

**Status:** Ready
