### PR TITLE
[RFC] ref/tag descriptions

### DIFF
--- a/src/duplicates.rs
+++ b/src/duplicates.rs
@@ -62,6 +62,7 @@ mod tests {
         let tags_vec1 = vec![Label {
             label_type: Type::Tag,
             label: "label1".to_owned(),
+            description: String::new(),
             path: Path::new("file1.rs").to_owned(),
             line_number: 1,
         }];
@@ -69,6 +70,7 @@ mod tests {
         let tags_vec2 = vec![Label {
             label_type: Type::Tag,
             label: "label2".to_owned(),
+            description: String::new(),
             path: Path::new("file2.rs").to_owned(),
             line_number: 2,
         }];
@@ -94,12 +96,14 @@ mod tests {
             Label {
                 label_type: Type::Tag,
                 label: "label".to_owned(),
+                description: String::new(),
                 path: Path::new("file1.rs").to_owned(),
                 line_number: 1,
             },
             Label {
                 label_type: Type::Tag,
                 label: "label".to_owned(),
+                description: String::new(),
                 path: Path::new("file2.rs").to_owned(),
                 line_number: 2,
             },

--- a/src/label.rs
+++ b/src/label.rs
@@ -30,6 +30,7 @@ impl fmt::Display for Type {
 pub struct Label {
     pub label_type: Type,
     pub label: String,
+    pub description: String,
     pub path: PathBuf,
     pub line_number: usize,
 }
@@ -71,6 +72,10 @@ pub fn parse<R: BufRead>(
                 labels.push(Label {
                     label_type,
                     label: captures.get(1).unwrap().as_str().to_owned(),
+                    description: captures
+                        .get(2)
+                        .map(|m| m.as_str().to_owned())
+                        .unwrap_or_default(),
                     path: path.to_owned(),
                     line_number: line_number + 1,
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn print_tabulated(data: Vec<[String; 2]>) {
     // the width is at least 3 to ensure there is enough room for 2 columns with a 1-space margin
     // between them [tag:min_terminal_width].
     let terminal_width = max(
-        term_size::dimensions_stdout().map_or(80, |(_height, width)| width),
+        term_size::dimensions_stdout().map_or(80, |(width, _height)| width),
         3,
     );
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -51,6 +51,7 @@ mod tests {
             Label {
                 label_type: Type::Tag,
                 label: "label1".to_owned(),
+                description: String::new(),
                 path: Path::new("file1.rs").to_owned(),
                 line_number: 1,
             },
@@ -59,6 +60,7 @@ mod tests {
         let refs = vec![Label {
             label_type: Type::Ref,
             label: "label1".to_owned(),
+            description: String::new(),
             path: Path::new("file1.rs").to_owned(),
             line_number: 1,
         }];
@@ -76,6 +78,7 @@ mod tests {
             Label {
                 label_type: Type::Tag,
                 label: "label1".to_owned(),
+                description: String::new(),
                 path: Path::new("file1.rs").to_owned(),
                 line_number: 1,
             },
@@ -85,12 +88,14 @@ mod tests {
             Label {
                 label_type: Type::Ref,
                 label: "label1".to_owned(),
+                description: String::new(),
                 path: Path::new("file1.rs").to_owned(),
                 line_number: 1,
             },
             Label {
                 label_type: Type::Ref,
                 label: "label2".to_owned(),
+                description: String::new(),
                 path: Path::new("file2.rs").to_owned(),
                 line_number: 2,
             },


### PR DESCRIPTION
If text follows a ref or tag after white-space or colon (:), parse it as
the label's description. That allows you to see context when listing
refs/tags.

Example:

```rust
 // [tag:FIXME]: stuff that must be fixed!
 // [ref:FIXME] this must be fixed because...
```

If there are any, they will be shown in a separate column.

Example from this repo:

```shell
  % cargo run -- list-tags
      Finished dev [unoptimized + debuginfo] target(s) in 0.02s
       Running `target/debug/tagref list-tags`
  ?label?                     and the syntax for \                          ./src/main.rs:48
  LABEL3                                                                    ./src/label.rs:181
  cities_nonempty             This function always returns a non-empty      ./README.md:33
                              list.
  colorless_tests                                                           ./toast.yml:123
  excluded_input_paths        Keep this in sync with [ref:gitignore].       ./toast.yml:135
  format_macros                                                             ./toast.yml:188
  gitignore                   Keep this in sync with                        ./.gitignore:1
                              [ref:excluded_input_paths].
  label1                                                                    ./src/label.rs:117
  label2                                                                    ./src/label.rs:159
  label3                                                                    ./src/label.rs:180
  label4                      [tag:label5]                                  ./src/label.rs:207
  label6                                                                    ./src/label.rs:232
  label7                                                                    ./src/label.rs:233
  min_terminal_width                                                        ./src/main.rs:116
  path_default                                                              ./src/main.rs:65
  ref_prefix_default                                                        ./src/main.rs:82
  rust_1.65.0                                                               ./toast.yml:61
  rust_fmt_nightly_2022-11-03 The                                           ./toast.yml:20
  tag_prefix_default                                                        ./src/main.rs:74
```

**Status:** request for comments