### PR TITLE
Revert the two-column layout behavior for the `list-tags`, `list-refs`, and `list-unused` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2023-04-03
+
+### Changed
+- The `list-tags`, `list-refs`, and `list-unused` subcommands now have their original behavior, the same as in v1.5.0. The fancy two-column output was too buggy.
+
 ## [1.6.1] - 2023-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,16 +72,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "colonnade"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4dbabb2946c90155114005a55086e08537be51d4c12af4ac215744e6e719851"
-dependencies = [
- "strip-ansi-escapes",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -192,24 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50686e0021c4136d1d453b2dfe059902278681512a34d4248435dc34b6b5c8ec"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "regex"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,15 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,15 +209,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "tagref"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "atty",
  "clap",
- "colonnade",
  "colored",
  "ignore",
  "regex",
- "term_size",
 ]
 
 [[package]]
@@ -293,55 +248,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "vte"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
-dependencies = [
- "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Tagref helps you maintain cross-references in your code."
@@ -12,11 +12,9 @@ readme = "README.md"
 
 [dependencies]
 atty = "0.2"
-colonnade = "1"
 colored = "1"
 ignore = "0.4"
 regex = "1"
-term_size = "0.3"
 
 [dependencies.clap]
 version = "2"

--- a/src/label.rs
+++ b/src/label.rs
@@ -13,19 +13,6 @@ pub enum Type {
     Ref,
 }
 
-impl fmt::Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Type::Tag => "tag",
-                Type::Ref => "ref",
-            },
-        )
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct Label {
     pub label_type: Type,
@@ -40,7 +27,10 @@ impl fmt::Display for Label {
         write!(
             f,
             "[{}:{}] @ {}:{}",
-            self.label_type,
+            match self.label_type {
+                Type::Tag => "tag",
+                Type::Ref => "ref",
+            },
             self.label,
             self.path.to_string_lossy(),
             self.line_number,


### PR DESCRIPTION
The new behavior was too buggy. In debug mode, it would panic due to https://github.com/dfhoughton/colonnade/issues/2 if the viewport was a certain size. In release mode, it would result in strange behavior due to integer underflow somewhere in Colonnade:

<img width="479" alt="Screenshot 2023-04-03 at 5 28 06 PM" src="https://user-images.githubusercontent.com/796574/229655425-9275568e-ac4e-4249-8d4b-0ee27b578728.png">

cc @epilys (sorry)

**Status:** Ready

**Fixes:** N/A