### PR TITLE
Add pre-commit.com support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: tagref
+  name: tagref
+  description: "Tagref helps you manage cross-references in your code."
+  entry: tagref
+  language: rust
+  files: ''
+  args: ['check']

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: "Tagref helps you manage cross-references in your code."
   entry: tagref
   language: rust
-  files: ''
+  pass_filenames: false
   args: ['check']


### PR DESCRIPTION
Make it work with https://pre-commit.com/#rust

Tested by adding

```
- repo: https://github.com/goretkin/tagref
  rev: 8592d879ebe809178490aec435f05d85066dc43d
  hooks:
    - id: tagref
      language_version: 1.74.0
```

to my project's `.pre-commit-config.yaml`

(After this PR lands, change to

```
- repo: https://github.com/stepchowfun/tagref
  rev: main
  hooks:
    - id: tagref
      language_version: 1.74.0
```
)

