### PR TITLE
Prevent multiple occurrences of --path from eating up the subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,8 @@ fn settings() -> Settings {
                 .long(PATH_OPTION)
                 .help("Adds the path of a directory to scan")
                 .default_value(".") // [tag:path_default]
-                .multiple(true),
+                .multiple(true)
+                .number_of_values(1),
         )
         .arg(
             Arg::with_name(TAG_SIGIL_OPTION)


### PR DESCRIPTION
In case the `--path` option was specified multiple times, it'd consider the subcommand as yet another path value, thereby causing the subcommand to default to `Check`.

Steps to reproduce:

```bash
  $ mkdir /tmp/{foo,bar}
  $ echo "[tag: hello]" > /tmp/foo/file.txt
  $ echo "[ref: hello]" > /tmp/bar/file.txt
  $ tagref -p /tmp/foo -p /tmp/bar list-tags
  1 tag, 1 tag reference, 0 file references, and 0 directory references validated in 2 files.
```

Notice that it prints the output of check subcommand instead of list-tags. This happens because the default behavior `Args::multiple(true)` in clap (version 2.x) is to allow multiple values per occurrence of the option.

Setting `Args::number_of_values(1)` in coordination with `Args::multiple(true)` fixes it. It allows multiple occurrences of the option but only one value per occurrence[1].

[1]: https://docs.rs/clap/2.34.0/clap/struct.Arg.html#method.multiple
