### PR TITLE
Remove `atty` crate and replace it with `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ dependencies = [
 name = "tagref"
 version = "1.10.0"
 dependencies = [
- "atty",
  "clap",
  "colored",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-atty = "0.2"
 colored = "1"
 ignore = "0.4"
 regex = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,12 @@ mod tag_references;
 mod walk;
 
 use {
-    atty::Stream,
     clap::{App, AppSettings, Arg, SubCommand},
     colored::Colorize,
     directive::compile_directive_regex,
     std::{
         collections::{HashMap, HashSet},
-        io::BufReader,
+        io::{self, BufReader, IsTerminal},
         path::{Path, PathBuf},
         process::exit,
         sync::{Arc, Mutex},
@@ -203,8 +202,7 @@ fn settings() -> Settings {
 #[allow(clippy::too_many_lines)]
 fn entry() -> Result<(), String> {
     // Determine whether to print colored output.
-    colored::control::set_override(atty::is(Stream::Stdout));
-
+    colored::control::set_override(io::stdout().is_terminal());
     // Parse the command-line options.
     let settings = settings();
 


### PR DESCRIPTION
The `std::io::IsTerminal` trait was introduced in Rust `1.70.0`, so it should not hinder any contributors.

**Status:** Ready