### PR TITLE
Add support for relative paths in file and dir references

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A directory reference guarantees that the given directory exists. For example:
 # This script will format the files in [dir:src].
 ```
 
-File and directory paths are relative to the working directory, which is typically the root of the project or repository.
+File and directory paths are relative to the working directory, which is typically the root of the project or repository. However, relative paths are also supported, for which the paths need to be prefixed with special directory expressions such as `./`, `../` etc. Note that `[file:doc.md]` will be considered relative to the current working directory. If it's intended to be relative to the referring file, it needs to be written as `[file:./doc.md]`.
 
 ## Tag names
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A directory reference guarantees that the given directory exists. For example:
 # This script will format the files in [dir:src].
 ```
 
-File and directory paths are relative to the working directory, which is typically the root of the project or repository. However, relative paths are also supported, for which the paths need to be prefixed with special directory expressions such as `./`, `../` etc. Note that `[file:doc.md]` will be considered relative to the current working directory. If it's intended to be relative to the referring file, it needs to be written as `[file:./doc.md]`.
+File and directory paths are relative to the working directory, which is typically the root of the project or repository. However, relative paths are also supported, for which the paths need to be prefixed with special directory expressions such as `./`, `../` etc. Note that `file:doc.md` will be considered relative to the current working directory. If it's intended to be relative to the referring file, it needs to be written as `file:./doc.md`.
 
 ## Tag names
 

--- a/src/dir_references.rs
+++ b/src/dir_references.rs
@@ -1,5 +1,5 @@
-use crate::directive::Directive;
-use std::fs::metadata;
+use crate::{directive::Directive, path_util::resolve_target_path};
+use std::{fs::metadata, path::Path};
 
 // This function checks that directory references actually point to directories. It returns a vector
 // of error strings.
@@ -7,7 +7,8 @@ pub fn check(refs: &[Directive]) -> Vec<String> {
     let mut errors = Vec::<String>::new();
 
     for dir in refs {
-        match metadata(&dir.label) {
+        let dir_path = resolve_target_path(&dir.path, Path::new(&dir.label));
+        match metadata(&dir_path) {
             Ok(metadata) => {
                 if !metadata.is_dir() {
                     errors.push(format!("{dir} does not point to a directory."));

--- a/src/file_references.rs
+++ b/src/file_references.rs
@@ -1,5 +1,5 @@
-use crate::directive::Directive;
-use std::fs::metadata;
+use crate::{directive::Directive, path_util::resolve_target_path};
+use std::{fs::metadata, path::Path};
 
 // This function checks that file references actually point to files. It returns a vector of error
 // strings.
@@ -7,7 +7,8 @@ pub fn check(refs: &[Directive]) -> Vec<String> {
     let mut errors = Vec::<String>::new();
 
     for file in refs {
-        match metadata(&file.label) {
+        let file_path = resolve_target_path(&file.path, Path::new(&file.label));
+        match metadata(&file_path) {
             Ok(metadata) => {
                 if !metadata.is_file() {
                     errors.push(format!("{file} does not point to a file."));

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod dir_references;
 mod directive;
 mod duplicates;
 mod file_references;
+mod path_util;
 mod tag_references;
 mod walk;
 

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -32,7 +32,7 @@ pub fn resolve_target_path(source: &Path, target: &Path) -> PathBuf {
 fn is_explicit_relative(path: &Path) -> bool {
     matches!(
         path.components().next(),
-        Some(Component::CurDir | Component::ParentDir)
+        Some(Component::CurDir | Component::ParentDir),
     )
 }
 
@@ -64,23 +64,21 @@ mod tests {
     #[test]
     fn test_resolve_target_path() {
         let result = resolve_target_path(
-            &Path::new("./docs/guidelines.md"),
-            &Path::new("../src/main.rs"),
+            Path::new("./docs/guidelines.md"),
+            Path::new("../src/main.rs"),
         );
         assert_eq!(PathBuf::from("src/main.rs"), result);
 
-        let result =
-            resolve_target_path(&Path::new("./docs/guidelines.md"), &Path::new("./arch.md"));
+        let result = resolve_target_path(Path::new("./docs/guidelines.md"), Path::new("./arch.md"));
         assert_eq!(PathBuf::from("docs/arch.md"), result);
 
         let result = resolve_target_path(
-            &Path::new("./docs/guidelines.md"),
-            &Path::new("../changelogs"),
+            Path::new("./docs/guidelines.md"),
+            Path::new("../changelogs"),
         );
         assert_eq!(PathBuf::from("changelogs"), result);
 
-        let result =
-            resolve_target_path(&Path::new("./docs/guidelines.md"), &Path::new("README.md"));
+        let result = resolve_target_path(Path::new("./docs/guidelines.md"), Path::new("README.md"));
         assert_eq!(PathBuf::from("README.md"), result);
     }
 }

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+use std::path::{Component, Path, PathBuf};
+
+/// Resolves target path relative to current working directory, in
+/// case it's relative to the source path.
+///
+/// The target path is considered to be relative to the source path if
+/// it's explicitly prefixed with the special directory expressions
+/// such as `./`, `../` etc. Otherwise it's already considered
+/// relative to the current working directory.
+///
+/// Example: Suppose source = ./docs/guidelines.md
+///
+/// If target = ../src/main.rs, result = src/main.rs
+/// If target = ./arch.md, result = docs/arch.md
+/// If target = README.md, result = README.md (no change)
+///
+/// Works similarly for files as well as dir paths.
+///
+pub fn resolve_target_path(source: &Path, target: &Path) -> PathBuf {
+    let resolved = if is_explicit_relative(target) {
+        // Relative to source path (use its parent if it's a file)
+        let base = source.parent().unwrap_or(source);
+        Cow::Owned(base.join(target))
+    } else {
+        // Already relative to current working directory
+        Cow::Borrowed(target)
+    };
+    normalize_path(&resolved)
+}
+
+fn is_explicit_relative(path: &Path) -> bool {
+    matches!(
+        path.components().next(),
+        Some(Component::CurDir | Component::ParentDir)
+    )
+}
+
+/// Normalizes a relative path by getting rid of special directory
+/// expressions such as `./`, `../` etc.
+///
+/// NOTE: Purely syntactic normalization (doesn't check if the file
+/// actually exists)
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
+            }
+            other => result.push(other.as_os_str()),
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::path_util::resolve_target_path;
+
+    #[test]
+    fn test_resolve_target_path() {
+        let result = resolve_target_path(
+            &Path::new("./docs/guidelines.md"),
+            &Path::new("../src/main.rs"),
+        );
+        assert_eq!(PathBuf::from("src/main.rs"), result);
+
+        let result =
+            resolve_target_path(&Path::new("./docs/guidelines.md"), &Path::new("./arch.md"));
+        assert_eq!(PathBuf::from("docs/arch.md"), result);
+
+        let result = resolve_target_path(
+            &Path::new("./docs/guidelines.md"),
+            &Path::new("../changelogs"),
+        );
+        assert_eq!(PathBuf::from("changelogs"), result);
+
+        let result =
+            resolve_target_path(&Path::new("./docs/guidelines.md"), &Path::new("README.md"));
+        assert_eq!(PathBuf::from("README.md"), result);
+    }
+}


### PR DESCRIPTION
The file and dir references are always considered relative to the current working dir. This commit allows the path to be specified relative to referring file.

My motivation behind this change is that I use (emacs) org-mode files for documentation in my projects. In org-mode, the syntax for internal links is something like `[[file:./architecture.org][Architecture]]`. It exactly matches tagref's default file-sigil. But in case of org, the paths are considered relative to the file. This change allows me to use tagref without having to specify a custom file-sigil. Moreover, I can use tagref's check functionality to ensure there are no broken links in the docs.

This change is backward compatible - A file path is considered relative to the file, only if it's explicitly prefixed with the special directory expressions such as `./`, `../`, etc. Otherwise it's considered relative to the current working dir, exactly the same as the original behaviour. 

Also note that the resolution of a path relative to the source file to path relative to the current working directory is only done at the time of the `check` operation. This means when the output of `list-files` and `list-dirs` commands will contain unresolved paths. Let me know what you think about this. 

**Status:** Ready for review

**Fixes:** #257
