### PR TITLE
Fix parent .gitignore handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-04-13
+
+### Fixed
+- `.gitignore` files above the scan root no longer affect which files Tagref scans.
+
 ## [1.12.0] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "tagref"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2024"
 description = "Tagref helps you maintain cross-references in your code."

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -24,6 +24,7 @@ pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
         WalkBuilder::new(path)
             .hidden(false)
             .require_git(false)
+            .parents(false)
             .overrides(
                 OverrideBuilder::new("")
                     .add("!.git/")


### PR DESCRIPTION
Fixes Tagref's filesystem walk so `.gitignore` files above the scan root do not affect which files are scanned. This keeps `.gitignore` support for files under the scan root while treating the scan root as the project boundary.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/tagref/issues/254