### PR TITLE
Update dependencies and CI pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: Build for Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -30,7 +30,7 @@ jobs:
 
         # The artifact name will contain the target triple, so the file name doesn't need to.
         mv artifacts/tagref-x86_64-unknown-linux-gnu artifacts/tagref
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: x86_64-unknown-linux-gnu
         path: artifacts/tagref
@@ -41,7 +41,7 @@ jobs:
 
         # The artifact name will contain the target triple, so the file name doesn't need to.
         mv artifacts/tagref-x86_64-unknown-linux-musl artifacts/tagref
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: x86_64-unknown-linux-musl
         path: artifacts/tagref
@@ -52,7 +52,7 @@ jobs:
 
         # The artifact name will contain the target triple, so the file name doesn't need to.
         mv artifacts/tagref-aarch64-unknown-linux-gnu artifacts/tagref
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: aarch64-unknown-linux-gnu
         path: artifacts/tagref
@@ -63,7 +63,7 @@ jobs:
 
         # The artifact name will contain the target triple, so the file name doesn't need to.
         mv artifacts/tagref-aarch64-unknown-linux-musl artifacts/tagref
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: aarch64-unknown-linux-musl
         path: artifacts/tagref
@@ -72,7 +72,7 @@ jobs:
     name: Build for Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -104,12 +104,12 @@ jobs:
 
         # Run the tests.
         NO_COLOR=true cargo test --locked # [ref:colorless_tests]
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: x86_64-pc-windows-msvc
         path: target/x86_64-pc-windows-msvc/release/tagref.exe
         if-no-files-found: error
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: aarch64-pc-windows-msvc
         path: target/aarch64-pc-windows-msvc/release/tagref.exe
@@ -118,7 +118,7 @@ jobs:
     name: Build for macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -143,12 +143,12 @@ jobs:
 
         # Run the tests.
         NO_COLOR=true cargo test --locked # [ref:colorless_tests]
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: x86_64-apple-darwin
         path: target/x86_64-apple-darwin/release/tagref
         if-no-files-found: error
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: aarch64-apple-darwin
         path: target/aarch64-apple-darwin/release/tagref
@@ -157,7 +157,7 @@ jobs:
     name: Install on macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -171,7 +171,7 @@ jobs:
     name: Install on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -189,12 +189,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
-    - uses: docker/login-action@v3
+    - uses: actions/checkout@v6.0.2
+    - uses: docker/login-action@v4.1.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8.0.1
       with:
         path: artifacts/
     - env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -211,9 +211,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"

--- a/toast.yml
+++ b/toast.yml
@@ -1,4 +1,4 @@
-image: ubuntu:24.04
+image: ubuntu:26.04
 default: build
 user: user
 command_prefix: |
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-04-17]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-04-25]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-04-17 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-04-25 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -83,8 +83,8 @@ tasks:
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-04-17].
-      rustup toolchain install nightly-2026-04-17 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-04-25].
+      rustup toolchain install nightly-2026-04-25 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.
@@ -112,7 +112,7 @@ tasks:
       cargo-online build --release
       cargo-online clippy --all-features --all-targets --workspace
 
-      # Delete the build artifacts.
+      # Delete the build artifacts for the placeholder package while keeping the dependencies.
       cargo-offline clean --package tagref
       cargo-offline clean --release --package tagref
 


### PR DESCRIPTION
## Summary
- refresh the Rust lockfile to the latest compatible crate versions
- update the pinned GitHub Actions versions in CI
- refresh the Toast base image and Rustfmt nightly pin

## Validation
- `cargo test`