### PR TITLE
Support tagref.yml project configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for configuring Tagref with a `tagref.yml` file.
 - Added the `--config` option for specifying the location of the config file.
+- Added support for configuring extra ignore rules in `tagref.yml`.
 
 ### Removed
 - Removed the command-line options for scan paths and sigils. Sigils are now configured in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-06-15
+
+### Added
+- Added support for configuring Tagref with a `tagref.yml` file.
+- Added the `--config` option for specifying the location of the config file.
+
+### Removed
+- Removed the command-line options for scan paths and sigils. Sigils are now configured in
+  `tagref.yml`.
+
 ## [1.12.1] - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -204,16 +216,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "linux-raw-sys"
@@ -300,6 +334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -356,12 +397,14 @@ dependencies = [
 
 [[package]]
 name = "tagref"
-version = "1.12.1"
+version = "1.13.0"
 dependencies = [
  "clap",
  "colored",
  "ignore",
  "regex",
+ "serde",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -418,4 +461,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagref"
-version = "1.12.1"
+version = "1.13.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2024"
 description = "Tagref helps you maintain cross-references in your code."
@@ -21,3 +21,5 @@ clap = { version = "4", features = ["derive", "wrap_help"] }
 colored = "3"
 ignore = "0.4"
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+yaml_serde = "0.10"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can use any naming convention you like. The Tagref authors prefer to use low
 
 ## Usage
 
-The easiest way to use Tagref is to add a `tagref.yml` file to the root of your project and then run the `tagref` command with no arguments. Tagref will look for the nearest `tagref.yml` in the current directory or one of its ancestors, recursively scan that project root, and check all the tags and references. If no `tagref.yml` file is found, Tagref will scan the current directory instead.
+The easiest way to use Tagref is to run the `tagref` command with no arguments. Tagref will look for the nearest `tagref.yml` in the current directory or one of its ancestors, recursively scan that directory, and check all the tags and references. If no `tagref.yml` file is found, Tagref will scan the current directory instead.
 
 Here are the supported command-line options:
 
@@ -86,9 +86,8 @@ ref_sigil: ref
 file_sigil: file
 dir_sigil: dir
 ignore_rules:
-  - target/
-  - generated/
-  - "*.snap"
+  - /artifacts/
+  - /target/
 ```
 
 The sigils determine which directives Tagref recognizes. For example, if `tag_sigil` is set to `note`, then `[note:foo]` declares a tag.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you use [pre-commit](https://pre-commit.com/), you can install Tagref by addi
 ```yaml
 repos:
 - repo: https://github.com/stepchowfun/tagref
-  rev: v1.13.0
+  rev: v1.12.1
   hooks:
   - id: tagref
 ```

--- a/README.md
+++ b/README.md
@@ -85,9 +85,15 @@ tag_sigil: tag
 ref_sigil: ref
 file_sigil: file
 dir_sigil: dir
+ignore_rules:
+  - target/
+  - generated/
+  - "*.snap"
 ```
 
 The sigils determine which directives Tagref recognizes. For example, if `tag_sigil` is set to `note`, then `[note:foo]` declares a tag.
+
+The `ignore_rules` field adds extra ignore rules, interpreted relative to the project root. These rules use the same pattern syntax as `.gitignore` files, but they only support exclusions. Rules beginning with `!` are rejected.
 
 ## Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A directory reference guarantees that the given directory exists. For example:
 # This script will format the files in [dir:src].
 ```
 
-By default, file and directory paths are relative to the working directory, which is typically the root of the project or repository. However, paths that start with a `.` or `..` component (e.g., `[file:./CHANGELOG.md]`) are considered relative to the directory containing the file where the reference originates.
+By default, file and directory paths are relative to the project root. However, paths that start with a `.` or `..` component (e.g., `[file:./CHANGELOG.md]`) are considered relative to the directory containing the file where the reference originates.
 
 ## Tag names
 
@@ -52,7 +52,9 @@ You can use any naming convention you like. The Tagref authors prefer to use low
 
 ## Usage
 
-The easiest way to use Tagref is to run the `tagref` command with no arguments. It will recursively scan the working directory and check all the tags and references. Here are the supported command-line options:
+The easiest way to use Tagref is to add a `tagref.yml` file to the root of your project and then run the `tagref` command with no arguments. Tagref will look for the nearest `tagref.yml` in the current directory or one of its ancestors, recursively scan that project root, and check all the tags and references. If no `tagref.yml` file is found, Tagref will scan the current directory instead.
+
+Here are the supported command-line options:
 
 ```
 Usage: tagref [OPTIONS] [COMMAND]
@@ -67,14 +69,25 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-  -v, --version                  Print version
-  -p, --path <PATH>              Add a directory to scan [default: .]
-  -t, --tag-sigil <TAG_SIGIL>    Set the sigil used for tags [default: tag]
-  -r, --ref-sigil <REF_SIGIL>    Set the sigil used for tag references [default: ref]
-  -f, --file-sigil <FILE_SIGIL>  Set the sigil used for file references [default: file]
-  -d, --dir-sigil <DIR_SIGIL>    Set the sigil used for directory references [default: dir]
-  -h, --help                     Print help
+  -v, --version          Print version
+  -c, --config <CONFIG>  Use a config file instead of searching for tagref.yml
+  -h, --help             Print help
 ```
+
+## Configuration
+
+The directory containing `tagref.yml` is the project root. If you want to use a config file at a specific path, pass `--config` or `-c`; Tagref will not search for another config file in that case.
+
+All fields are optional. An empty `tagref.yml` file is valid.
+
+```yaml
+tag_sigil: tag
+ref_sigil: ref
+file_sigil: file
+dir_sigil: dir
+```
+
+The sigils determine which directives Tagref recognizes. For example, if `tag_sigil` is set to `note`, then `[note:foo]` declares a tag.
 
 ## Installation instructions
 
@@ -134,7 +147,7 @@ If you use [pre-commit](https://pre-commit.com/), you can install Tagref by addi
 ```yaml
 repos:
 - repo: https://github.com/stepchowfun/tagref
-  rev: v1.12.1
+  rev: v1.13.0
   hooks:
   - id: tagref
 ```

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/tagref"
 
   # Which version to download
-  RELEASE="v${VERSION:-1.13.0}"
+  RELEASE="v${VERSION:-1.12.1}"
 
   # Determine which binary to download.
   FILENAME=''

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/tagref"
 
   # Which version to download
-  RELEASE="v${VERSION:-1.12.1}"
+  RELEASE="v${VERSION:-1.13.0}"
 
   # Determine which binary to download.
   FILENAME=''

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,11 @@ pub fn load(config_path: Option<&Path>) -> Result<Config, String> {
         env::current_dir().map_err(|error| format!("Error getting current directory: {error}"))?;
 
     if let Some(config_path) = config_path {
-        let config_path = make_absolute(&invocation_dir, config_path);
+        let config_path = if config_path.is_absolute() {
+            config_path.to_owned()
+        } else {
+            invocation_dir.join(config_path)
+        };
         if !config_path.is_file() {
             return Err(format!(
                 "No config file found at {}.",
@@ -128,13 +132,4 @@ fn load_from_file(path: &Path) -> Result<Config, String> {
             .unwrap_or_else(|| DEFAULT_DIR_SIGIL.to_owned()),
         ignore_rules,
     })
-}
-
-// Resolves a command-line path relative to the invocation directory
-fn make_absolute(invocation_dir: &Path, path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_owned()
-    } else {
-        invocation_dir.join(path)
-    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,22 +4,22 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// The name of the config file Tagref searches for.
+// The name of the config file Tagref searches for
 const CONFIG_FILE_NAME: &str = "tagref.yml";
 
-// The default sigil for tag declarations.
+// The default sigil for tag declarations
 const DEFAULT_TAG_SIGIL: &str = "tag";
 
-// The default sigil for tag references.
+// The default sigil for tag references
 const DEFAULT_REF_SIGIL: &str = "ref";
 
-// The default sigil for file references.
+// The default sigil for file references
 const DEFAULT_FILE_SIGIL: &str = "file";
 
-// The default sigil for directory references.
+// The default sigil for directory references
 const DEFAULT_DIR_SIGIL: &str = "dir";
 
-// The resolved configuration used by Tagref at runtime.
+// The resolved configuration used by Tagref at runtime
 #[derive(Debug)]
 pub struct Config {
     pub project_root: PathBuf,
@@ -29,7 +29,7 @@ pub struct Config {
     pub dir_sigil: String,
 }
 
-// The on-disk `tagref.yml` schema.
+// The on-disk `tagref.yml` schema
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -40,7 +40,7 @@ struct RawConfig {
     dir_sigil: Option<String>,
 }
 
-// Loads the configuration, either from an explicit config path or by searching for one.
+// Loads the configuration, either from an explicit config path or by searching for one
 pub fn load(config_path: Option<&Path>) -> Result<Config, String> {
     let invocation_dir =
         env::current_dir().map_err(|error| format!("Error getting current directory: {error}"))?;
@@ -69,7 +69,7 @@ pub fn load(config_path: Option<&Path>) -> Result<Config, String> {
     }
 }
 
-// Finds the nearest config file at or above `start`.
+// Finds the nearest config file at or above `start`
 fn find_config(start: &Path) -> Option<PathBuf> {
     start
         .ancestors()
@@ -77,7 +77,7 @@ fn find_config(start: &Path) -> Option<PathBuf> {
         .find(|path| path.is_file())
 }
 
-// Parses a config file and applies defaults.
+// Parses a config file and applies defaults
 fn load_from_file(path: &Path) -> Result<Config, String> {
     let project_root = path
         .parent()
@@ -117,7 +117,7 @@ fn load_from_file(path: &Path) -> Result<Config, String> {
     })
 }
 
-// Resolves a command-line path relative to the invocation directory.
+// Resolves a command-line path relative to the invocation directory
 fn make_absolute(invocation_dir: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() {
         path.to_owned()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,127 @@
+use serde::Deserialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+// The name of the config file Tagref searches for.
+const CONFIG_FILE_NAME: &str = "tagref.yml";
+
+// The default sigil for tag declarations.
+const DEFAULT_TAG_SIGIL: &str = "tag";
+
+// The default sigil for tag references.
+const DEFAULT_REF_SIGIL: &str = "ref";
+
+// The default sigil for file references.
+const DEFAULT_FILE_SIGIL: &str = "file";
+
+// The default sigil for directory references.
+const DEFAULT_DIR_SIGIL: &str = "dir";
+
+// The resolved configuration used by Tagref at runtime.
+#[derive(Debug)]
+pub struct Config {
+    pub project_root: PathBuf,
+    pub tag_sigil: String,
+    pub ref_sigil: String,
+    pub file_sigil: String,
+    pub dir_sigil: String,
+}
+
+// The on-disk `tagref.yml` schema.
+#[allow(clippy::struct_field_names)]
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    tag_sigil: Option<String>,
+    ref_sigil: Option<String>,
+    file_sigil: Option<String>,
+    dir_sigil: Option<String>,
+}
+
+// Loads the configuration, either from an explicit config path or by searching for one.
+pub fn load(config_path: Option<&Path>) -> Result<Config, String> {
+    let invocation_dir =
+        env::current_dir().map_err(|error| format!("Error getting current directory: {error}"))?;
+
+    if let Some(config_path) = config_path {
+        let config_path = make_absolute(&invocation_dir, config_path);
+        if !config_path.is_file() {
+            return Err(format!(
+                "No config file found at {}.",
+                config_path.to_string_lossy(),
+            ));
+        }
+        return load_from_file(&config_path);
+    }
+
+    if let Some(config_path) = find_config(&invocation_dir) {
+        load_from_file(&config_path)
+    } else {
+        Ok(Config {
+            project_root: invocation_dir,
+            tag_sigil: DEFAULT_TAG_SIGIL.to_owned(),
+            ref_sigil: DEFAULT_REF_SIGIL.to_owned(),
+            file_sigil: DEFAULT_FILE_SIGIL.to_owned(),
+            dir_sigil: DEFAULT_DIR_SIGIL.to_owned(),
+        })
+    }
+}
+
+// Finds the nearest config file at or above `start`.
+fn find_config(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .map(|ancestor| ancestor.join(CONFIG_FILE_NAME))
+        .find(|path| path.is_file())
+}
+
+// Parses a config file and applies defaults.
+fn load_from_file(path: &Path) -> Result<Config, String> {
+    let project_root = path
+        .parent()
+        .ok_or_else(|| format!("Config file {} has no parent.", path.to_string_lossy()))?
+        .to_owned();
+    let contents = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "Error reading config file {}: {error}",
+            path.to_string_lossy(),
+        )
+    })?;
+    let raw_config = if contents.trim().is_empty() {
+        RawConfig::default()
+    } else {
+        yaml_serde::from_str::<RawConfig>(&contents).map_err(|error| {
+            format!(
+                "Error parsing config file {}: {error}",
+                path.to_string_lossy(),
+            )
+        })?
+    };
+
+    Ok(Config {
+        project_root,
+        tag_sigil: raw_config
+            .tag_sigil
+            .unwrap_or_else(|| DEFAULT_TAG_SIGIL.to_owned()),
+        ref_sigil: raw_config
+            .ref_sigil
+            .unwrap_or_else(|| DEFAULT_REF_SIGIL.to_owned()),
+        file_sigil: raw_config
+            .file_sigil
+            .unwrap_or_else(|| DEFAULT_FILE_SIGIL.to_owned()),
+        dir_sigil: raw_config
+            .dir_sigil
+            .unwrap_or_else(|| DEFAULT_DIR_SIGIL.to_owned()),
+    })
+}
+
+// Resolves a command-line path relative to the invocation directory.
+fn make_absolute(invocation_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_owned()
+    } else {
+        invocation_dir.join(path)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub ref_sigil: String,
     pub file_sigil: String,
     pub dir_sigil: String,
+    pub ignore_rules: Vec<String>,
 }
 
 // The on-disk `tagref.yml` schema
@@ -38,6 +39,7 @@ struct RawConfig {
     ref_sigil: Option<String>,
     file_sigil: Option<String>,
     dir_sigil: Option<String>,
+    ignore_rules: Option<Vec<String>>,
 }
 
 // Loads the configuration, either from an explicit config path or by searching for one
@@ -65,6 +67,7 @@ pub fn load(config_path: Option<&Path>) -> Result<Config, String> {
             ref_sigil: DEFAULT_REF_SIGIL.to_owned(),
             file_sigil: DEFAULT_FILE_SIGIL.to_owned(),
             dir_sigil: DEFAULT_DIR_SIGIL.to_owned(),
+            ignore_rules: Vec::new(),
         })
     }
 }
@@ -99,6 +102,15 @@ fn load_from_file(path: &Path) -> Result<Config, String> {
             )
         })?
     };
+    let ignore_rules = raw_config.ignore_rules.unwrap_or_default();
+    for ignore_rule in &ignore_rules {
+        if ignore_rule.starts_with('!') {
+            return Err(format!(
+                "Invalid ignore rule `{ignore_rule}` in {}: ignore_rules only supports exclusions.",
+                path.to_string_lossy(),
+            ));
+        }
+    }
 
     Ok(Config {
         project_root,
@@ -114,6 +126,7 @@ fn load_from_file(path: &Path) -> Result<Config, String> {
         dir_sigil: raw_config
             .dir_sigil
             .unwrap_or_else(|| DEFAULT_DIR_SIGIL.to_owned()),
+        ignore_rules,
     })
 }
 

--- a/src/dir_references.rs
+++ b/src/dir_references.rs
@@ -3,12 +3,13 @@ use std::{fs::metadata, path::Path};
 
 // This function checks that directory references actually point to directories. It returns a vector
 // of error strings.
-pub fn check(refs: &[Directive]) -> Vec<String> {
+pub fn check(project_root: &Path, refs: &[Directive]) -> Vec<String> {
     let mut errors = Vec::<String>::new();
 
     for dir in refs {
-        // The `unwrap` is safe because `file.path` should always exist in some parent directory.
+        // The `unwrap` is safe because `dir.path` should always exist in some parent directory.
         match metadata(resolve_target_path(
+            project_root,
             dir.path.parent().unwrap(),
             Path::new(&dir.label),
         )) {

--- a/src/file_references.rs
+++ b/src/file_references.rs
@@ -3,12 +3,13 @@ use std::{fs::metadata, path::Path};
 
 // This function checks that file references actually point to files. It returns a vector of error
 // strings.
-pub fn check(refs: &[Directive]) -> Vec<String> {
+pub fn check(project_root: &Path, refs: &[Directive]) -> Vec<String> {
     let mut errors = Vec::<String>::new();
 
     for file in refs {
         // The `unwrap` is safe because `file.path` should always exist in some parent directory.
         match metadata(resolve_target_path(
+            project_root,
             file.path.parent().unwrap(),
             Path::new(&file.label),
         )) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,12 @@ fn entry() -> Result<(), String> {
     let file_regex_clone = file_regex.clone();
     let dir_regex_clone = dir_regex.clone();
     let project_root = config.project_root;
+    let ignore_rules = config.ignore_rules;
     let project_root_clone = project_root.clone();
     let files_scanned = walk::walk(
         std::slice::from_ref(&project_root),
         &project_root,
+        &ignore_rules,
         move |file_path, file| {
             let display_path = path_util::make_relative_path(&project_root_clone, file_path);
             let directives = directive::parse(
@@ -138,7 +140,7 @@ fn entry() -> Result<(), String> {
             files_clone.lock().unwrap().extend(directives.files); // Safe assuming no poisoning
             dirs_clone.lock().unwrap().extend(directives.dirs); // Safe assuming no poisoning
         },
-    );
+    )?;
 
     // Decide what to do based on the subcommand.
     match cli.command.unwrap_or(Subcommand::Check) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,13 +119,14 @@ fn entry() -> Result<(), String> {
         &project_root,
         &ignore_rules,
         move |file_path, file| {
-            let display_path = path_util::make_relative_path(&project_root_clone, file_path);
+            // The unwrap is safe because the walker is rooted at `project_root_clone`.
+            let display_path = file_path.strip_prefix(&project_root_clone).unwrap();
             let directives = directive::parse(
                 &tag_regex_clone,
                 &ref_regex_clone,
                 &file_regex_clone,
                 &dir_regex_clone,
-                &display_path,
+                display_path,
                 BufReader::new(file),
             );
             for tag in directives.tags {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod count;
 mod dir_references;
 mod directive;
@@ -39,44 +40,11 @@ struct Cli {
 
     #[arg(
         short,
-        long = "path",
-        value_name = "PATH",
-        help = "Add a directory to scan",
-        default_value = "."
-    )]
-    paths: Vec<PathBuf>,
-
-    #[arg(
-        short,
         long,
-        help = "Set the sigil used for tags",
-        default_value = "tag"
+        value_name = "CONFIG",
+        help = "Use a config file instead of searching for tagref.yml"
     )]
-    tag_sigil: String,
-
-    #[arg(
-        short,
-        long,
-        help = "Set the sigil used for tag references",
-        default_value = "ref"
-    )]
-    ref_sigil: String,
-
-    #[arg(
-        short,
-        long,
-        help = "Set the sigil used for file references",
-        default_value = "file"
-    )]
-    file_sigil: String,
-
-    #[arg(
-        short,
-        long,
-        help = "Set the sigil used for directory references",
-        default_value = "dir"
-    )]
-    dir_sigil: String,
+    config: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Option<Subcommand>,
@@ -121,11 +89,14 @@ fn entry() -> Result<(), String> {
     // Parse the command-line options.
     let cli = Cli::parse();
 
+    // Load the configuration.
+    let config = config::load(cli.config.as_deref())?;
+
     // Compile the regular expressions in advance.
-    let tag_regex = compile_directive_regex(&cli.tag_sigil);
-    let ref_regex = compile_directive_regex(&cli.ref_sigil);
-    let file_regex = compile_directive_regex(&cli.file_sigil);
-    let dir_regex = compile_directive_regex(&cli.dir_sigil);
+    let tag_regex = compile_directive_regex(&config.tag_sigil);
+    let ref_regex = compile_directive_regex(&config.ref_sigil);
+    let file_regex = compile_directive_regex(&config.file_sigil);
+    let dir_regex = compile_directive_regex(&config.dir_sigil);
 
     // Parse all the tags and references.
     let tags = Arc::new(Mutex::new(HashMap::new()));
@@ -140,27 +111,33 @@ fn entry() -> Result<(), String> {
     let ref_regex_clone = ref_regex.clone();
     let file_regex_clone = file_regex.clone();
     let dir_regex_clone = dir_regex.clone();
-    let files_scanned = walk::walk(&cli.paths, move |file_path, file| {
-        let directives = directive::parse(
-            &tag_regex_clone,
-            &ref_regex_clone,
-            &file_regex_clone,
-            &dir_regex_clone,
-            file_path,
-            BufReader::new(file),
-        );
-        for tag in directives.tags {
-            tags_clone
-                .lock()
-                .unwrap() // Safe assuming no poisoning
-                .entry(tag.label.clone())
-                .or_insert_with(Vec::new)
-                .push(tag.clone());
-        }
-        refs_clone.lock().unwrap().extend(directives.refs); // Safe assuming no poisoning
-        files_clone.lock().unwrap().extend(directives.files); // Safe assuming no poisoning
-        dirs_clone.lock().unwrap().extend(directives.dirs); // Safe assuming no poisoning
-    });
+    let project_root = config.project_root;
+    let project_root_clone = project_root.clone();
+    let files_scanned = walk::walk(
+        std::slice::from_ref(&project_root),
+        move |file_path, file| {
+            let display_path = path_util::make_relative_path(&project_root_clone, file_path);
+            let directives = directive::parse(
+                &tag_regex_clone,
+                &ref_regex_clone,
+                &file_regex_clone,
+                &dir_regex_clone,
+                &display_path,
+                BufReader::new(file),
+            );
+            for tag in directives.tags {
+                tags_clone
+                    .lock()
+                    .unwrap() // Safe assuming no poisoning
+                    .entry(tag.label.clone())
+                    .or_insert_with(Vec::new)
+                    .push(tag.clone());
+            }
+            refs_clone.lock().unwrap().extend(directives.refs); // Safe assuming no poisoning
+            files_clone.lock().unwrap().extend(directives.files); // Safe assuming no poisoning
+            dirs_clone.lock().unwrap().extend(directives.dirs); // Safe assuming no poisoning
+        },
+    );
 
     // Decide what to do based on the subcommand.
     match cli.command.unwrap_or(Subcommand::Check) {
@@ -183,10 +160,13 @@ fn entry() -> Result<(), String> {
             errors.extend(tag_references::check(&tags, &refs));
 
             // Check the file references. The `unwrap` is safe assuming no poisoning.
-            errors.extend(file_references::check(&files.lock().unwrap()));
+            errors.extend(file_references::check(
+                &project_root,
+                &files.lock().unwrap(),
+            ));
 
             // Check the directory references. The `unwrap` is safe assuming no poisoning.
-            errors.extend(dir_references::check(&dirs.lock().unwrap()));
+            errors.extend(dir_references::check(&project_root, &dirs.lock().unwrap()));
 
             // Check for any errors and report the result.
             if errors.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn entry() -> Result<(), String> {
         &project_root,
         &ignore_rules,
         move |file_path, file| {
-            // The unwrap is safe because the walker is rooted at `project_root_clone`.
+            // The `unwrap` is safe because the walker is rooted at `project_root_clone`.
             let display_path = file_path.strip_prefix(&project_root_clone).unwrap();
             let directives = directive::parse(
                 &tag_regex_clone,

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,13 +120,13 @@ fn entry() -> Result<(), String> {
         &ignore_rules,
         move |file_path, file| {
             // The `unwrap` is safe because the walker is rooted at `project_root_clone`.
-            let display_path = file_path.strip_prefix(&project_root_clone).unwrap();
+            let relative_file_path = file_path.strip_prefix(&project_root_clone).unwrap();
             let directives = directive::parse(
                 &tag_regex_clone,
                 &ref_regex_clone,
                 &file_regex_clone,
                 &dir_regex_clone,
-                display_path,
+                relative_file_path,
                 BufReader::new(file),
             );
             for tag in directives.tags {

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ fn entry() -> Result<(), String> {
     let project_root_clone = project_root.clone();
     let files_scanned = walk::walk(
         std::slice::from_ref(&project_root),
+        &project_root,
         move |file_path, file| {
             let display_path = path_util::make_relative_path(&project_root_clone, file_path);
             let directives = directive::parse(

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -13,12 +13,6 @@ pub fn resolve_target_path(project_root: &Path, source_dir: &Path, target_path: 
     }
 }
 
-// Returns `path` relative to `root`, if possible
-pub fn make_relative_path(root: &Path, path: &Path) -> PathBuf {
-    path.strip_prefix(root)
-        .map_or_else(|_| path.to_owned(), Path::to_owned)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::path_util::resolve_target_path;

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -1,17 +1,22 @@
 use std::path::{Component, Path, PathBuf};
 
 // Resolves `target_path` relative to `source_dir` if `target_path` begins with a `.` or `..`
-// component. Otherwise, `target_path` is interpreted as being relative to the current working
-// directory and returned as is.
-pub fn resolve_target_path(source_dir: &Path, target_path: &Path) -> PathBuf {
+// component. Otherwise, `target_path` is interpreted as being relative to the project root.
+pub fn resolve_target_path(project_root: &Path, source_dir: &Path, target_path: &Path) -> PathBuf {
     if matches!(
         target_path.components().next(),
         Some(Component::CurDir | Component::ParentDir),
     ) {
-        source_dir.join(target_path)
+        project_root.join(source_dir).join(target_path)
     } else {
-        target_path.to_owned()
+        project_root.join(target_path)
     }
+}
+
+// Returns `path` relative to `root`, if possible.
+pub fn make_relative_path(root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root)
+        .map_or_else(|_| path.to_owned(), Path::to_owned)
 }
 
 #[cfg(test)]
@@ -19,37 +24,49 @@ mod tests {
     use crate::path_util::resolve_target_path;
     use std::path::{Path, PathBuf};
 
-    // Thanks to [ref:tagref_check], the following file and direcotry references will be checked
+    // Thanks to [ref:tagref_check], the following file and directory references will be checked
     // as a form of integration test:
     //
-    // - [file:toast.yml]    // Relative to current working directory (project root)
-    // - [file:../toast.yml] // A file in the parent directory
-    // - [file:./main.rs]    // A sibling file
-    // - [dir:src]           // Relative to current working directory (project root)
-    // - [dir:../src]        // A directory in the parent directory
+    // - [file:toast.yml]    // Relative to the project root
+    // - [file:../toast.yml] // Relative to the directory containing this file
+    // - [file:./main.rs]    // Relative to the directory containing this file
+    // - [dir:src]           // Relative to the project root
+    // - [dir:../src]        // Relative to the directory containing this file
     // - [dir:.]             // The directory containing this file
 
     #[test]
     fn resolve_target_path_parent_dir() {
         assert_eq!(
-            resolve_target_path(Path::new("docs/guidelines.md"), Path::new("../src/main.rs")),
-            PathBuf::from("docs/guidelines.md/../src/main.rs"),
+            resolve_target_path(
+                Path::new("project"),
+                Path::new("docs"),
+                Path::new("../src/main.rs"),
+            ),
+            PathBuf::from("project/docs/../src/main.rs"),
         );
     }
 
     #[test]
     fn resolve_target_path_current_dir() {
         assert_eq!(
-            resolve_target_path(Path::new("docs/guidelines.md"), Path::new("./src/main.rs")),
-            PathBuf::from("docs/guidelines.md/./src/main.rs"),
+            resolve_target_path(
+                Path::new("project"),
+                Path::new("docs"),
+                Path::new("./src/main.rs"),
+            ),
+            PathBuf::from("project/docs/./src/main.rs"),
         );
     }
 
     #[test]
     fn resolve_target_path_non_relative() {
         assert_eq!(
-            resolve_target_path(Path::new("docs/guidelines.md"), Path::new("src/main.rs")),
-            PathBuf::from("src/main.rs"),
+            resolve_target_path(
+                Path::new("project"),
+                Path::new("docs"),
+                Path::new("src/main.rs"),
+            ),
+            PathBuf::from("project/src/main.rs"),
         );
     }
 }

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -13,7 +13,7 @@ pub fn resolve_target_path(project_root: &Path, source_dir: &Path, target_path: 
     }
 }
 
-// Returns `path` relative to `root`, if possible.
+// Returns `path` relative to `root`, if possible
 pub fn make_relative_path(root: &Path, path: &Path) -> PathBuf {
     path.strip_prefix(root)
         .map_or_else(|_| path.to_owned(), Path::to_owned)

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -13,6 +13,7 @@ use std::{
 // skips over symlinks. The number of files traversed is returned.
 pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
     paths: &[PathBuf],
+    current_dir: &Path,
     callback: T,
 ) -> usize {
     // Keep track of the number of files traversed, and allow multiple threads to update it.
@@ -22,11 +23,12 @@ pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
     for path in paths {
         // Traverse the filesystem in parallel.
         WalkBuilder::new(path)
+            .current_dir(current_dir)
             .hidden(false)
             .require_git(false)
             .parents(false)
             .overrides(
-                OverrideBuilder::new("")
+                OverrideBuilder::new(current_dir)
                     .add("!.git/")
                     .unwrap() // Safe by manual inspection
                     .add("!.hg/")

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,4 +1,7 @@
-use ignore::{WalkBuilder, WalkState, overrides::OverrideBuilder};
+use ignore::{
+    WalkBuilder, WalkState,
+    overrides::{Override, OverrideBuilder},
+};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -14,10 +17,12 @@ use std::{
 pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
     paths: &[PathBuf],
     current_dir: &Path,
+    ignore_rules: &[String],
     callback: T,
-) -> usize {
+) -> Result<usize, String> {
     // Keep track of the number of files traversed, and allow multiple threads to update it.
     let files_scanned = Arc::new(AtomicUsize::new(0));
+    let overrides = build_overrides(current_dir, ignore_rules)?;
 
     // Scan each of the given paths.
     for path in paths {
@@ -27,15 +32,7 @@ pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
             .hidden(false)
             .require_git(false)
             .parents(false)
-            .overrides(
-                OverrideBuilder::new(current_dir)
-                    .add("!.git/")
-                    .unwrap() // Safe by manual inspection
-                    .add("!.hg/")
-                    .unwrap() // Safe by manual inspection
-                    .build()
-                    .unwrap(), // Safe by manual inspection
-            )
+            .overrides(overrides.clone())
             .build_parallel()
             .run(|| {
                 // These clones will be moved into the closure below, and that closure will be sent
@@ -67,5 +64,23 @@ pub fn walk<T: 'static + Clone + Send + FnMut(&Path, File)>(
     }
 
     // Return the number of files traversed.
-    files_scanned.load(Ordering::SeqCst)
+    Ok(files_scanned.load(Ordering::SeqCst))
+}
+
+// Builds high-precedence ignore overrides for the walker
+fn build_overrides(current_dir: &Path, ignore_rules: &[String]) -> Result<Override, String> {
+    let mut override_builder = OverrideBuilder::new(current_dir);
+    override_builder
+        .add("!.git/")
+        .unwrap() // Safe by manual inspection
+        .add("!.hg/")
+        .unwrap(); // Safe by manual inspection
+    for ignore_rule in ignore_rules {
+        override_builder
+            .add(&format!("!{ignore_rule}"))
+            .map_err(|error| format!("Error parsing ignore rule `{ignore_rule}`: {error}"))?;
+    }
+    override_builder
+        .build()
+        .map_err(|error| format!("Error building ignore rules: {error}"))
 }

--- a/tagref.yml
+++ b/tagref.yml
@@ -1,4 +1,0 @@
-tag_sigil: tag
-ref_sigil: ref
-file_sigil: file
-dir_sigil: dir

--- a/tagref.yml
+++ b/tagref.yml
@@ -1,0 +1,4 @@
+tag_sigil: tag
+ref_sigil: ref
+file_sigil: file
+dir_sigil: dir


### PR DESCRIPTION
Support per-project `tagref.yml` configuration so Tagref can discover the project root from any subdirectory. This adds `--config`, moves sigil configuration into YAML, adds high-precedence `ignore_rules`, removes the old scan-path and sigil flags, updates docs, and bumps the minor version to `1.13.0`.

**Status:** Ready

**Fixes:** [N/A](https://github.com/stepchowfun/tagref/issues/283)