### PR TITLE
Update release references to v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you use [pre-commit](https://pre-commit.com/), you can install Tagref by addi
 ```yaml
 repos:
 - repo: https://github.com/stepchowfun/tagref
-  rev: v1.12.1
+  rev: v1.13.0
   hooks:
   - id: tagref
 ```

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/tagref"
 
   # Which version to download
-  RELEASE="v${VERSION:-1.12.1}"
+  RELEASE="v${VERSION:-1.13.0}"
 
   # Determine which binary to download.
   FILENAME=''


### PR DESCRIPTION
Update the default version in `install.sh` and the README pre-commit example to the latest published release, v1.13.0.

**Status:** Ready

**Fixes:** N/A