### PR TITLE
Update dependencies and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.96.1 --no-self-update # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 --no-self-update # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -124,8 +124,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.96.1 # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -204,8 +204,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.96.1 # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust.warnings = "deny"
 [dependencies]
 clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
 colored = "3.1.1"
-ignore = "0.4.27"
-regex = "1.12.4"
+ignore = "0.4.28"
+regex = "1.13.0"
 serde = { version = "1.0.228", features = ["derive"] }
 yaml_serde = "0.10.4"

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-08]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-09]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-07-08 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-07-09 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -73,18 +73,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.96.1].
+      # Install stable Rust [tag:rust_1.97.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.96.1 \
+        --default-toolchain 1.97.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-08].
-      rustup toolchain install nightly-2026-07-08 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-09].
+      rustup toolchain install nightly-2026-07-09 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
Updates the Rust toolchain from 1.96.1 to 1.97.0 and nightly rustfmt from 2026-07-08 to 2026-07-09.

Also updates direct dependencies ignore 0.4.27 -> 0.4.28 and regex 1.12.4 -> 1.13.0, plus regex-automata in Cargo.lock. Changelog/diff review found no required code migration: regex adds the new regex! macro, while ignore adds richer errors, some walking improvements, and support for GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM in core.excludesFile discovery.

**Status:** Ready

**Fixes:** N/A

